### PR TITLE
Set soundfontPath depending on linux distribution

### DIFF
--- a/karaoke/play_linux.go
+++ b/karaoke/play_linux.go
@@ -6,13 +6,31 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/cemmanouilidis/go.platform"
 )
 
-const soundfontPath = "/usr/share/sounds/sf2/FluidR3_GM.sf2"
+var soundfontPaths = map[string]string{
+	"arch":   "/usr/share/soundfonts/FluidR3_GM2-2.sf2",
+	"debian": "/usr/share/sounds/sf2/FluidR3_GM.sf2",
+}
 
 // Play takes a given .midi file and plays it.
 func Play(localmid string) error {
+	// detect linux distribution
+	dist, _, _, err := platform.LinuxDistribution()
+	if err != nil {
+		return fmt.Errorf("detecting linux distribution failed: ", err)
+	}
+
+	// set soundfontPath depending on linux distribution
+	soundfontPath := soundfontPaths["debian"] //default
+	if _, ok := soundfontPaths[dist]; ok {
+		soundfontPath = soundfontPaths[dist]
+	}
+
 	cmd := exec.Command("fluidsynth", "-a", "alsa", "-m", "alsa_seq", "-l", "-i", soundfontPath, localmid)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("running `%s %s` failed: %s, %v", cmd.Path, strings.Join(cmd.Args, " "), out, err)
 	}


### PR DESCRIPTION
Since cliaoke didn't work on my Arch machine, I made some changes to detect if cliaoke runs on debian or arch to set path to soundfontPath accordingly.

The changes requires to use my go package github.com/cemmanouilidis/go.platform 
